### PR TITLE
Fix suppliers report test case

### DIFF
--- a/app/models/spree/calculator/per_item_decorator.rb
+++ b/app/models/spree/calculator/per_item_decorator.rb
@@ -13,14 +13,15 @@ module Spree
     def compute(object = nil)
       return 0 if object.nil?
 
-      preferred_amount * line_items_for(object).reduce(0) do |sum, value|
-        value_to_add = if matching_products.blank? || matching_products.include?(value.product)
-                         value.quantity
+      number_of_line_items = line_items_for(object).reduce(0) do |sum, line_item|
+        value_to_add = if matching_products.blank? || matching_products.include?(line_item.product)
+                         line_item.quantity
                        else
                          0
                        end
         sum + value_to_add
       end
+      preferred_amount * number_of_line_items
     end
   end
 end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/scope.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/scope.rb
@@ -342,12 +342,21 @@ module OrderManagement
 
         def group_data
           chain_to_scope do
-            group("enterprise_fees.id", "enterprises.id", "customers.id", "hubs.id",
-                  "spree_payment_methods.id", "spree_shipping_methods.id",
-                  "adjustment_metadata.enterprise_role", "spree_tax_categories.id",
-                  "product_tax_categories.id", "spree_adjustments.source_type",
-                  "adjustment_source_distributors.id", "incoming_exchange_enterprises.id",
-                  "outgoing_exchange_enterprises.id")
+            group(
+              "enterprise_fees.id",
+              "enterprises.id",
+              "customers.id",
+              "hubs.id",
+              "spree_payment_methods.id",
+              "spree_shipping_methods.id",
+              "adjustment_metadata.enterprise_role",
+              "spree_tax_categories.id",
+              "product_tax_categories.id",
+              "spree_adjustments.source_type",
+              "adjustment_source_distributors.id",
+              "incoming_exchange_enterprises.id",
+              "outgoing_exchange_enterprises.id"
+            )
           end
         end
 
@@ -355,12 +364,16 @@ module OrderManagement
           chain_to_scope do
             select(
               <<-JOIN_STRING.strip_heredoc
-                SUM(spree_adjustments.amount) AS total_amount, spree_payment_methods.name AS
-                  payment_method_name, spree_shipping_methods.name AS shipping_method_name,
-                  hubs.name AS hub_name, enterprises.name AS enterprise_name,
-                  enterprise_fees.fee_type AS fee_type, customers.name AS customer_name,
-                  customers.email AS customer_email, enterprise_fees.fee_type AS fee_type,
-                  enterprise_fees.name AS fee_name, spree_tax_categories.name AS tax_category_name,
+                SUM(spree_adjustments.amount) AS total_amount,
+                  spree_payment_methods.name AS payment_method_name,
+                  spree_shipping_methods.name AS shipping_method_name,
+                  hubs.name AS hub_name,
+                  enterprises.name AS enterprise_name,
+                  enterprise_fees.fee_type AS fee_type,
+                  customers.name AS customer_name,
+                  customers.email AS customer_email,
+                  enterprise_fees.name AS fee_name,
+                  spree_tax_categories.name AS tax_category_name,
                   enterprise_fees.inherits_tax_category AS enterprise_fee_inherits_tax_category,
                   product_tax_categories.name AS product_tax_category_name,
                   adjustment_metadata.enterprise_role AS placement_enterprise_role,

--- a/engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/report_service_spec.rb
+++ b/engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/report_service_spec.rb
@@ -610,10 +610,14 @@ describe OrderManagement::Reports::EnterpriseFeeSummary::ReportService do
 
     describe "for specified shipping methods" do
       let!(:shipping_method_a) do
-        create(:shipping_method, name: "Shipping A", distributors: [distributor])
+        method = create(:shipping_method, name: "Shipping A", distributors: [distributor])
+        method.calculator.update_attribute(:preferred_amount, 1)
+        method
       end
       let!(:shipping_method_b) do
-        create(:shipping_method, name: "Shipping B", distributors: [distributor])
+        method = create(:shipping_method, name: "Shipping B", distributors: [distributor])
+        method.calculator.update_attribute(:preferred_amount, 1)
+        method
       end
       let!(:shipping_method_c) do
         create(:shipping_method, name: "Shipping C", distributors: [distributor])
@@ -638,10 +642,14 @@ describe OrderManagement::Reports::EnterpriseFeeSummary::ReportService do
 
     describe "for specified payment methods" do
       let!(:payment_method_a) do
-        create(:payment_method, name: "Payment A", distributors: [distributor])
+        method = create(:payment_method, name: "Payment A", distributors: [distributor])
+        method.calculator.update_attribute(:preferred_amount, 1)
+        method
       end
       let!(:payment_method_b) do
-        create(:payment_method, name: "Payment B", distributors: [distributor])
+        method = create(:payment_method, name: "Payment B", distributors: [distributor])
+        method.calculator.update_attribute(:preferred_amount, 1)
+        method
       end
       let!(:payment_method_c) do
         create(:payment_method, name: "Payment C", distributors: [distributor])

--- a/engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/report_service_spec.rb
+++ b/engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/report_service_spec.rb
@@ -517,9 +517,9 @@ describe OrderManagement::Reports::EnterpriseFeeSummary::ReportService do
       let!(:producer_b) { create(:supplier_enterprise, name: "Producer B") }
       let!(:producer_c) { create(:supplier_enterprise, name: "Producer C") }
 
-      let!(:fee_a) { create(:enterprise_fee, name: "Fee A", enterprise: producer_a) }
-      let!(:fee_b) { create(:enterprise_fee, name: "Fee B", enterprise: producer_b) }
-      let!(:fee_c) { create(:enterprise_fee, name: "Fee C", enterprise: producer_c) }
+      let!(:fee_a) { create(:enterprise_fee, name: "Fee A", enterprise: producer_a, amount: 1) }
+      let!(:fee_b) { create(:enterprise_fee, name: "Fee B", enterprise: producer_b, amount: 1) }
+      let!(:fee_c) { create(:enterprise_fee, name: "Fee C", enterprise: producer_c, amount: 1) }
 
       let!(:product_a) { create(:product, supplier: producer_a) }
       let!(:product_b) { create(:product, supplier: producer_b) }
@@ -588,9 +588,9 @@ describe OrderManagement::Reports::EnterpriseFeeSummary::ReportService do
     end
 
     describe "for specified enterprise fees" do
-      let!(:fee_a) { create(:enterprise_fee, name: "Fee A", enterprise: distributor) }
-      let!(:fee_b) { create(:enterprise_fee, name: "Fee B", enterprise: distributor) }
-      let!(:fee_c) { create(:enterprise_fee, name: "Fee C", enterprise: distributor) }
+      let!(:fee_a) { create(:enterprise_fee, name: "Fee A", enterprise: distributor, amount: 1) }
+      let!(:fee_b) { create(:enterprise_fee, name: "Fee B", enterprise: distributor, amount: 1) }
+      let!(:fee_c) { create(:enterprise_fee, name: "Fee C", enterprise: distributor, amount: 1) }
 
       let!(:variant) { prepare_variant(outgoing_exchange_fees: variant_outgoing_exchange_fees) }
       let!(:variant_outgoing_exchange_fees) { [fee_a, fee_b, fee_c] }


### PR DESCRIPTION
#### What? Why?

Goes one step further based on #4996 to fix the build. You can read the commits for the full story but here's what I found out.

The calculators of the adjustments related to the enterprise fees created in the test setup have a preferred_amount of 0. So, when computed, the adjustments' amounts end up being `0 = 0 * 1 line_item`.

Then, the ReportService filters these out in `#exclude_groups_with_zero_total` from the result set. This is why the assertions can't find them in `totals`.

I fixed the specs related to ship/payment method in a non-elegant way because their calculators get created somewhere deep in the factories where we can't access directly from the spec file. Ideas to improve them are welcome.